### PR TITLE
Update brew-graph.rb

### DIFF
--- a/brew-graph.rb
+++ b/brew-graph.rb
@@ -101,7 +101,7 @@ class BrewGraph
       deps = brew_deps(arg).split("\n")
       deps.each do |s|
         node,deps = s.split(':')
-        data[node] = deps.nil? ? nil : deps.strip.split(' ')
+        data[node] = deps.nil? ? nil : deps.strip.split(' ').uniq
       end
       data
     end


### PR DESCRIPTION
It seems that brew itself returns duplicates:

![brew-deps-dupes](https://cloud.githubusercontent.com/assets/18142/10500100/776bc91a-728a-11e5-8eee-ce040578a267.png)

In most cases it doesn't _hurt_ to remove duplicates, because there are not supposed to be any :-)